### PR TITLE
chore: Allow magic value comparisons in test files

### DIFF
--- a/cookiecutter-pypackage/pyproject.toml
+++ b/cookiecutter-pypackage/pyproject.toml
@@ -165,6 +165,7 @@ lint.pydocstyle.convention = "google"
     "S311",     # Random numbers in our tests aren't for cryptographic purposes
     "SLF001",   # Private member access
     "T201",     # Allow print in tests as this is preferred over logging
+    "PLR2004"   # Allow "magic value comparison", e.g. "assert len(list) == 5"
 ]
 "**/__init__.py" = [
     "F401", # Imported but unused

--- a/{{cookiecutter.repo_name}}/pyproject.toml
+++ b/{{cookiecutter.repo_name}}/pyproject.toml
@@ -167,6 +167,7 @@ lint.pydocstyle.convention = "google"
     "S311",     # Random numbers in our tests aren't for cryptographic purposes
     "SLF001",   # Private member access
     "T201",     # Allow print in tests as this is preferred over logging
+    "PLR2004"   # Allow "magic value comparison", e.g. "assert len(list) == 5"
 ]
 "**/__init__.py" = [
     "F401", # Imported but unused


### PR DESCRIPTION
Disable Ruff rule PLR2004 for test files to allow magic value
comparisons, which are standard practice in test assertions
(e.g., "assert len(list) == 5").

This rule is overly restrictive for test code where hard-coded
expected values are common and expected.