### PR TITLE
ci: Group dependabot updates by production and development dependencies

### DIFF
--- a/cookiecutter-pypackage/.github/dependabot.yml
+++ b/cookiecutter-pypackage/.github/dependabot.yml
@@ -11,3 +11,8 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+    groups:
+      production:
+        dependency-type: "production"
+      development:
+        dependency-type: "development"

--- a/{{cookiecutter.repo_name}}/.github/dependabot.yml
+++ b/{{cookiecutter.repo_name}}/.github/dependabot.yml
@@ -11,3 +11,8 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+    groups:
+      production:
+        dependency-type: "production"
+      development:
+        dependency-type: "development"


### PR DESCRIPTION
Adds `groups` configuration to the Dependabot setup so that updates are
batched into two PRs instead of one per package:

- **production** — covers `[project].dependencies`
- **development** — covers all `[dependency-groups]` entries
