### PR TITLE
fix: Fix CI file removal

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -29,9 +29,9 @@ _REMOVE_PATHS_CI = {
 REMOVE_PATHS = []
 
 match "{{cookiecutter.ci_tool}}":
-    case "github_actions":
-        REMOVE_PATHS.extend(_REMOVE_PATHS_CI["jenkins"])
     case "jenkins":
+        REMOVE_PATHS.extend(_REMOVE_PATHS_CI["jenkins"])
+    case "github_actions":
         REMOVE_PATHS.extend(_REMOVE_PATHS_CI["github_actions"])
     case "None":
         REMOVE_PATHS.extend(


### PR DESCRIPTION
We introduced a bug in https://github.com/vorausrobotik/voraus-python-template/pull/15, resulting in the wrong CI files being removed. This PR restores the intended behavior.